### PR TITLE
Support uppercase file suffix

### DIFF
--- a/handlers/process_file.rb
+++ b/handlers/process_file.rb
@@ -51,8 +51,8 @@ module DataPipeline
 
       def next_bucket_finder(key)
         case key
-        when /csv\Z/ then @environment['AMR_DATA_BUCKET']
-        when /zip\Z/ then @environment['COMPRESSED_BUCKET']
+        when /csv\Z/i then @environment['AMR_DATA_BUCKET']
+        when /zip\Z/i then @environment['COMPRESSED_BUCKET']
         else @environment['UNPROCESSABLE_BUCKET']
         end
       end

--- a/spec/handlers/process_file_spec.rb
+++ b/spec/handlers/process_file_spec.rb
@@ -47,6 +47,10 @@ describe DataPipeline::Handlers::ProcessFile do
             { body: unknown_file }
           when  'sheffield-gas/Sheffield City Council - Energy Sparks (Daily Email)20190303.csv'
             { body: sheffield_gas_csv }
+          when 'sheffield/export.CSV'
+            { body: sheffield_csv }
+          when 'sheffield/export.ZIP'
+            { body: sheffield_zip }
           else
             'NotFound'
           end
@@ -71,7 +75,18 @@ describe DataPipeline::Handlers::ProcessFile do
       end
     end
 
-    describe 'when the file is a CSV' do
+    describe 'when the file is a .CSV' do
+      let(:event){ DataPipeline::Support::Events.uppercase_csv_added }
+
+      it 'puts the attachment file in the AMR_DATA_BUCKET from the environment using the key of the object added' do
+        request = client.api_requests.last
+        expect(request[:operation_name]).to eq(:put_object)
+        expect(request[:params][:key]).to eq('sheffield/export.CSV')
+        expect(request[:params][:bucket]).to eq('data-bucket')
+      end
+    end
+
+    describe 'when the file is a .csv file' do
 
       let(:event){ DataPipeline::Support::Events.csv_added }
 
@@ -80,7 +95,6 @@ describe DataPipeline::Handlers::ProcessFile do
         expect(request[:operation_name]).to eq(:put_object)
         expect(request[:params][:key]).to eq('sheffield/export.csv')
         expect(request[:params][:bucket]).to eq('data-bucket')
-
       end
 
       it 'returns a success code' do
@@ -136,7 +150,23 @@ describe DataPipeline::Handlers::ProcessFile do
 
     end
 
-    describe 'when the file is a zip' do
+    describe 'when the file is a .ZIP' do
+
+      let(:event){ DataPipeline::Support::Events.uppercase_zip_added }
+
+      it 'puts the attachment file in the COMPRESSED_BUCKET from the environment using the key of the object added' do
+        request = client.api_requests.last
+        expect(request[:operation_name]).to eq(:put_object)
+        expect(request[:params][:key]).to eq('sheffield/export.ZIP')
+        expect(request[:params][:bucket]).to eq('compressed-bucket')
+      end
+
+      it 'returns a success code' do
+        expect(response[:statusCode]).to eq(200)
+      end
+    end
+
+    describe 'when the file is a .zip' do
 
       let(:event){ DataPipeline::Support::Events.zip_added }
 

--- a/spec/support/events.rb
+++ b/spec/support/events.rb
@@ -63,6 +63,10 @@ module DataPipeline
         file_event(filename: 'sheffield/export.csv', bucket: 'file-bucket')
       end
 
+      def self.uppercase_csv_added
+        file_event(filename: 'sheffield/export.CSV', bucket: 'file-bucket')
+      end
+
       def self.cr_csv_added
         file_event(filename: 'sheffield/cr.csv', bucket: 'file-bucket')
       end
@@ -85,6 +89,10 @@ module DataPipeline
 
       def self.zip_added
         file_event(filename: 'sheffield/export.zip', bucket: 'file-bucket')
+      end
+
+      def self.uppercase_zip_added
+        file_event(filename: 'sheffield/export.ZIP', bucket: 'file-bucket')
       end
 
       def self.image_added


### PR DESCRIPTION
Some files are arriving named as `.CSV` and they're being rejected. Our regex test for suffix is case sensitive.

This changes filename matching to support `.CSV` and `.ZIP` as well as `.csv` and `.zip`.