### PR TITLE
Increase timeouts for potentially long running tasks

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -63,6 +63,7 @@ package:
 functions:
   unpack-attachments:
     handler: handler.DataPipeline::Handler.unpack_attachments
+    timeout: 10
     events:
       - s3: ${self:provider.environment.INBOX_BUCKET}
   process-file:
@@ -75,6 +76,7 @@ functions:
       - s3: ${self:provider.environment.COMPRESSED_BUCKET}
   convert:
     handler: handler.DataPipeline::Handler.convert_file
+    timeout: 30
     events:
       - s3: ${self:provider.environment.SPREADSHEET_BUCKET}
 


### PR DESCRIPTION
We recently had some timeouts from the spreadsheet conversion lambda. This PR updates the timeout for the function to 30s. This should be more than enough to process the data we are receiving.

I've also slightly increased the timeout for the unpack attachments function as this occasionally has to download data linked in the body of an email rather than extracting attachments. I didn't increase this to 30s as I wanted to reduce having the lambda running if there was a network issue or problem with the remote service.